### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 obj/*
 game
 game.exe
+
+# Generated Files
+*.obj
+*.o
+*.so
+*.lib
+Debug/
+x64/
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@ game.exe
 *.so
 *.lib
 Debug/
+Release/
 x64/
+
+# Visual Studio User files
+.vs/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PDCurses"]
+	path = PDCurses
+	url = https://github.com/wmcbrine/PDCurses.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "PDCurses"]
 	path = PDCurses
 	url = https://github.com/wmcbrine/PDCurses.git
+	ignore = untracked

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# Makefile used for Linux and macOs builds
+
 IDIR = include
 ODIR = obj
 CC = gcc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snake
 A Snake game made in C using libncurses
 
-The executable is built in the <code>obj</code> folder for Linux and macOS. For Windows, it is built inside the <code>Debug</code> folder.
+For Windows, the executable is built inside the <code>Debug</code> or the <code>Release</code> folder, depending on the configuration chosen while building through Visual Studio. The executable is called <code>game</code> on Linux and macOS.
 
 **Note**: PDCurses submodule is required to build on Windows but is NOT required for Linux and macOS. However, Xcode is required on macOS. On Linux, it required to install the ncurses package for your distro.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Snake
 A Snake game made in C using libncurses
 
-The executable is built in the <code>$PROJECT_ROOT/obj</code> folder
+The executable is built in the <code>obj</code> folder for Linux and macOS. For Windows, it is built inside the <code>Debug</code> folder.
+
+**Note**: PDCurses submodule is required to build on Windows but is NOT required for Linux and macOS. However, Xcode is required on macOS. On Linux, it required to install the ncurses package for your distro.
 
 ## Building on Linux
 1. Install libncurses
+    - For Debian based distros: <code>apt-get install libncurses5-dev</code>
+    - For Fedora: <code>yum install ncurses-devel</code>
+    - For OpenSUSE: <code>zypper in ncurses-devel</code>
 2. Clone the repository
 3. Run <code>make</code>
 4. Run the executable <code>game</code>
@@ -16,3 +21,10 @@ The executable is built in the <code>$PROJECT_ROOT/obj</code> folder
 4. Run <code>make</code>
 
 Run <code>make clean</code> to remove compiled files
+
+## Building on Windows with Visual Studio 2017
+1. Clone the repository with <code>--recurse-submodules</code> flag.
+2. Navigate to <code>PDCurses\wincon</code> and run <code>nmake -f Makefile.vc</code> using the Developer Command Prompt.
+3. Open the <code>Snake.sln</code> with Visual Studio. Select x86 Debug or Release and click on the run button.
+
+We are able to to make only 32-bit binaries as PDCurses currently provides only a 32 bit library.

--- a/Snake.sln
+++ b/Snake.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Snake", "Snake.vcxproj", "{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Debug|x64.ActiveCfg = Debug|x64
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Debug|x64.Build.0 = Debug|x64
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Debug|x86.ActiveCfg = Debug|Win32
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Debug|x86.Build.0 = Debug|Win32
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Release|x64.ActiveCfg = Release|x64
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Release|x64.Build.0 = Release|x64
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Release|x86.ActiveCfg = Release|Win32
+		{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {15061F2B-6289-40EE-A027-D234573969CA}
+	EndGlobalSection
+EndGlobal

--- a/Snake.sln
+++ b/Snake.sln
@@ -5,6 +5,15 @@ VisualStudioVersion = 15.0.28010.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Snake", "Snake.vcxproj", "{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Miscellaneous items", "Miscellaneous items", "{0004B78E-DE7A-41AF-A613-D05335B58EF2}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		.gitmodules = .gitmodules
+		LICENSE = LICENSE
+		Makefile = Makefile
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/Snake.vcxproj
+++ b/Snake.vcxproj
@@ -99,6 +99,8 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>PDCurses\wincon</AdditionalLibraryDirectories>
+      <AdditionalDependencies>pdcurses.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/Snake.vcxproj
+++ b/Snake.vcxproj
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{CBDE49F3-52C5-40B7-8FFB-AC9E308BDD8E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>include;PDCurses;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>PDCurses\wincon\pdcurses.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>include; PDCurses;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>include; PDCurses</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>PDCurses\wincon\pcdurses.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="arraylist.c" />
+    <ClCompile Include="game.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\arraylist.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="pdcurses\wincon\pdcurses.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Snake.vcxproj.filters
+++ b/Snake.vcxproj.filters
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="arraylist.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="game.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\arraylist.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="pdcurses\wincon\pdcurses.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/Snake.vcxproj.user
+++ b/Snake.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>


### PR DESCRIPTION
This pull request creates <code>Snake.sln</code> which can be opened directly in Visual Studio 2017. PDCurses which was required separately has now been added as a submodule to the repository.

To compile and build on Windows natively, just follow the steps as mentioned in the updated README. It is still necessary to manually compile PDCurses before opening the Visual Studio solution to ensure that everything works correctly.

Only x86 binaries are currently possible. This is because PDCurses doesn't provide a 64-bit library.